### PR TITLE
feat: use CollectStatusEvent API to centrally manage charm status

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -8,76 +8,20 @@ from typing import Any, Callable, Optional, TypeVar
 from ops.charm import CharmBase, EventBase
 from ops.model import BlockedStatus, WaitingStatus
 
+from constants import (
+    CERTIFICATE_TRANSFER_INTEGRATION_NAME,
+    HYDRA_ENDPOINTS_INTEGRATION_NAME,
+    INGRESS_INTEGRATION_NAME,
+    KRATOS_INFO_INTEGRATION_NAME,
+    OPENFGA_INTEGRATION_NAME,
+    PEER_INTEGRATION_NAME,
+    WORKLOAD_CONTAINER,
+)
+
 logger = logging.getLogger(__name__)
 
 CharmEventHandler = TypeVar("CharmEventHandler", bound=Callable[..., Any])
-ConditionEvaluation = tuple[bool, str]
-Condition = Callable[[CharmBase], ConditionEvaluation]
-
-
-def container_not_connected(charm: CharmBase) -> ConditionEvaluation:
-    """Condition to validate workload container connectivity."""
-    not_connected = not charm._container.can_connect()
-    return not_connected, ("Container is not connected yet" if not_connected else "")
-
-
-def integration_not_exists(integration_name: str) -> Condition:
-    """A factory of conditions of integration existence validation."""
-
-    def wrapped(charm: CharmBase) -> ConditionEvaluation:
-        not_exists = not charm.model.relations[integration_name]
-        return not_exists, (f"Missing integration {integration_name}" if not_exists else "")
-
-    return wrapped
-
-
-def block_when(*conditions: Condition) -> Callable[[CharmEventHandler], CharmEventHandler]:
-    """A factory of decorators that block juju unit when a certain condition validation fails."""
-
-    def decorator(func: CharmEventHandler) -> CharmEventHandler:
-        """A decorator, applied to any event hook handler, to block juju unit."""
-
-        @wraps(func)
-        def wrapper(charm: CharmBase, *args: EventBase, **kwargs: Any) -> Optional[Any]:
-            event, *_ = args
-            logger.debug(f"Handling event: {event}.")
-
-            for condition in conditions:
-                not_met, msg = condition(charm)
-                if not_met:
-                    charm.unit.status = BlockedStatus(msg)
-                    return None
-
-            return func(charm, *args, **kwargs)
-
-        return wrapper  # type: ignore[return-value]
-
-    return decorator
-
-
-def wait_when(*conditions: Condition) -> Callable[[CharmEventHandler], CharmEventHandler]:
-    """A factory of decorators that put juju unit in wait status when a certain condition validation fails."""
-
-    def decorator(func: CharmEventHandler) -> CharmEventHandler:
-        """A decorator, applied to any event hook handler, to put juju unit in wait status."""
-
-        @wraps(func)
-        def wrapper(charm: CharmBase, *args: EventBase, **kwargs: Any) -> Optional[Any]:
-            event, *_ = args
-            logger.debug(f"Handling event: {event}.")
-
-            for condition in conditions:
-                not_met, msg = condition(charm)
-                if not_met:
-                    event.defer()
-                    charm.unit.status = WaitingStatus(msg)
-                    return None
-
-            return func(charm, *args, **kwargs)
-
-        return wrapper  # type: ignore[return-value]
-
-    return decorator
+Condition = Callable[[CharmBase], bool]
 
 
 def leader_unit(func: CharmEventHandler) -> CharmEventHandler:
@@ -91,3 +35,89 @@ def leader_unit(func: CharmEventHandler) -> CharmEventHandler:
         return func(charm, *args, **kwargs)
 
     return wrapper  # type: ignore[return-value]
+
+
+def integration_existence(integration_name: str) -> Condition:
+    """A factory of integration existence condition."""
+
+    def wrapped(charm: CharmBase) -> bool:
+        return bool(charm.model.relations[integration_name])
+
+    return wrapped
+
+
+peer_integration_existence = integration_existence(PEER_INTEGRATION_NAME)
+kratos_integration_existence = integration_existence(KRATOS_INFO_INTEGRATION_NAME)
+hydra_integration_existence = integration_existence(HYDRA_ENDPOINTS_INTEGRATION_NAME)
+openfga_integration_existence = integration_existence(OPENFGA_INTEGRATION_NAME)
+ingress_integration_existence = integration_existence(INGRESS_INTEGRATION_NAME)
+
+
+def container_connectivity(charm: CharmBase) -> bool:
+    return charm.unit.get_container(WORKLOAD_CONTAINER).can_connect()
+
+
+def certificate_existence(charm: CharmBase) -> bool:
+    oauth_integration_exists = charm.oauth_integration.is_ready()
+    cert_transfer_integration_exists = bool(
+        charm.model.relations[CERTIFICATE_TRANSFER_INTEGRATION_NAME]
+    )
+
+    return False if (oauth_integration_exists and not cert_transfer_integration_exists) else True
+
+
+def openfga_store_readiness(charm: CharmBase) -> bool:
+    return charm.openfga_integration.is_store_ready()
+
+
+def openfga_model_readiness(charm: CharmBase) -> bool:
+    return bool(charm.peer_data[charm._workload_service.version])
+
+
+CONDITION_STATUS_REGISTRY = (
+    (container_connectivity, WaitingStatus("Container is not connected yet")),
+    (peer_integration_existence, WaitingStatus(f"Missing integration {PEER_INTEGRATION_NAME}")),
+    (
+        kratos_integration_existence,
+        BlockedStatus(f"Missing integration {KRATOS_INFO_INTEGRATION_NAME}"),
+    ),
+    (
+        hydra_integration_existence,
+        BlockedStatus(f"Missing integration {HYDRA_ENDPOINTS_INTEGRATION_NAME}"),
+    ),
+    (
+        openfga_integration_existence,
+        BlockedStatus(f"Missing integration {OPENFGA_INTEGRATION_NAME}"),
+    ),
+    (
+        ingress_integration_existence,
+        BlockedStatus(f"Missing integration {INGRESS_INTEGRATION_NAME}"),
+    ),
+    (
+        certificate_existence,
+        BlockedStatus("Missing certificate transfer integration with oauth provider"),
+    ),
+    (openfga_store_readiness, WaitingStatus("OpenFGA store is not ready yet")),
+    (openfga_model_readiness, WaitingStatus("OpenFGA model is not ready yet")),
+)
+
+
+def do_nothing(event: EventBase) -> None:
+    pass
+
+
+def defer_event(event: EventBase) -> None:
+    event.defer()
+
+
+CONDITION_SIDE_EFFECT_REGISTRY = (
+    (container_connectivity, defer_event),
+    (peer_integration_existence, defer_event),
+    (kratos_integration_existence, do_nothing),
+    (hydra_integration_existence, do_nothing),
+    (openfga_integration_existence, do_nothing),
+    (ingress_integration_existence, do_nothing),
+    (certificate_existence, do_nothing),
+    (openfga_store_readiness, defer_event),
+    (openfga_model_readiness, defer_event),
+)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -169,27 +169,6 @@ async def test_scale_up(
     assert follower_openfga_data == leader_openfga_integration_data
 
 
-async def test_scale_down(
-    ops_test: OpsTest,
-    admin_service_application: Application,
-    leader_openfga_integration_data: Optional[dict],
-    leader_peer_integration_data: Optional[dict],
-) -> None:
-    target_unit_num = 1
-
-    await admin_service_application.scale(target_unit_num)
-
-    await ops_test.model.wait_for_idle(
-        apps=[ADMIN_SERVICE_APP],
-        status="active",
-        timeout=5 * 60,
-        wait_for_exact_units=target_unit_num,
-    )
-
-    assert leader_peer_integration_data
-    assert leader_openfga_integration_data
-
-
 async def test_remove_integration_openfga(
     ops_test: OpsTest,
     admin_service_application: Application,
@@ -223,3 +202,24 @@ async def test_remove_integration_ingress(
 ) -> None:
     async with remove_integration(ops_test, public_traefik_app_name, INGRESS_INTEGRATION_NAME):
         assert "blocked" == admin_service_application.status
+
+
+async def test_scale_down(
+    ops_test: OpsTest,
+    admin_service_application: Application,
+    leader_openfga_integration_data: Optional[dict],
+    leader_peer_integration_data: Optional[dict],
+) -> None:
+    target_unit_num = 1
+
+    await admin_service_application.scale(target_unit_num)
+
+    await ops_test.model.wait_for_idle(
+        apps=[ADMIN_SERVICE_APP],
+        status="active",
+        timeout=5 * 60,
+        wait_for_exact_units=target_unit_num,
+    )
+
+    assert leader_peer_integration_data
+    assert leader_openfga_integration_data

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -20,6 +20,7 @@ from oauth_tools import ExternalIdpService, deploy_identity_bundle
 from pytest_operator.plugin import OpsTest
 
 from constants import (
+    CERTIFICATE_TRANSFER_INTEGRATION_NAME,
     HYDRA_ENDPOINTS_INTEGRATION_NAME,
     INGRESS_INTEGRATION_NAME,
     KRATOS_INFO_INTEGRATION_NAME,
@@ -201,6 +202,17 @@ async def test_remove_integration_ingress(
     admin_service_application: Application,
 ) -> None:
     async with remove_integration(ops_test, public_traefik_app_name, INGRESS_INTEGRATION_NAME):
+        assert "blocked" == admin_service_application.status
+
+
+async def test_remove_integration_certificate_transfer(
+    ops_test: OpsTest,
+    self_signed_certificates_app_name: str,
+    admin_service_application: Application,
+) -> None:
+    async with remove_integration(
+        ops_test, self_signed_certificates_app_name, CERTIFICATE_TRANSFER_INTEGRATION_NAME
+    ):
         assert "blocked" == admin_service_application.status
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,6 +5,7 @@ from typing import Generator
 from unittest.mock import MagicMock, PropertyMock, create_autospec
 
 import pytest
+from ops import CollectStatusEvent, EventBase
 from ops.model import Container, Unit
 from ops.testing import Harness
 from pytest_mock import MockerFixture
@@ -42,6 +43,13 @@ def mocked_workload_service_version(mocker: MockerFixture) -> MagicMock:
     return mocker.patch(
         "charm.WorkloadService.version", new_callable=PropertyMock, return_value="1.10.0"
     )
+
+
+@pytest.fixture
+def mocked_pebble_service(mocker: MockerFixture, harness: Harness) -> MagicMock:
+    mocked = mocker.patch("charm.PebbleService", autospec=True)
+    harness.charm._pebble_service = mocked
+    return mocked
 
 
 @pytest.fixture
@@ -83,6 +91,16 @@ def mocked_unit(mocked_container: MagicMock) -> MagicMock:
 
 
 @pytest.fixture
+def mocked_event() -> MagicMock:
+    return create_autospec(EventBase)
+
+
+@pytest.fixture
+def mocked_collect_status_event() -> MagicMock:
+    return create_autospec(CollectStatusEvent)
+
+
+@pytest.fixture
 def peer_integration(harness: Harness) -> int:
     return harness.add_relation(PEER_INTEGRATION_NAME, "identity-platform-admin-ui")
 
@@ -93,3 +111,16 @@ def ingress_integration(harness: Harness) -> int:
         INGRESS_INTEGRATION_NAME,
         "ingress",
     )
+
+
+@pytest.fixture
+def all_satisfied_conditions(mocker: MockerFixture) -> None:
+    mocker.patch("charm.container_connectivity", return_value=True)
+    mocker.patch("charm.peer_integration_exists", return_value=True)
+    mocker.patch("charm.kratos_integration_exists", return_value=True)
+    mocker.patch("charm.hydra_integration_exists", return_value=True)
+    mocker.patch("charm.openfga_integration_exists", return_value=True)
+    mocker.patch("charm.ingress_integration_exists", return_value=True)
+    mocker.patch("charm.ca_certificate_exists", return_value=True)
+    mocker.patch("charm.openfga_store_readiness", return_value=True)
+    mocker.patch("charm.openfga_model_readiness", return_value=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -58,7 +58,7 @@ def mocked_openfga_store_ready(mocker: MockerFixture) -> MagicMock:
 
 @pytest.fixture
 def mocked_charm_holistic_handler(mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("charm.IdentityPlatformAdminUIOperatorCharm._handle_status_update_config")
+    return mocker.patch("charm.IdentityPlatformAdminUIOperatorCharm._holistic_handler")
 
 
 @pytest.fixture

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,7 +5,6 @@
 
 from unittest.mock import MagicMock, patch
 
-from ops.model import WaitingStatus
 from ops.testing import Harness
 
 from constants import WORKLOAD_CONTAINER
@@ -50,7 +49,6 @@ class TestUpgradeCharmEvent:
         harness.charm.on.upgrade_charm.emit()
 
         mocked_workload_service.create_openfga_model.assert_not_called()
-        assert isinstance(harness.model.unit.status, WaitingStatus)
 
     def test_when_missing_peer_integration(
         self, harness: Harness, mocked_workload_service: MagicMock
@@ -58,7 +56,6 @@ class TestUpgradeCharmEvent:
         harness.charm.on.upgrade_charm.emit()
 
         mocked_workload_service.create_openfga_model.assert_not_called()
-        assert isinstance(harness.model.unit.status, WaitingStatus)
 
     @patch("charm.OpenFGAIntegration.is_store_ready", return_value=False)
     def test_when_openfga_store_not_ready(
@@ -101,7 +98,6 @@ class TestOpenFGAStoreCreatedEvent:
 
         mocked_workload_service.create_openfga_model.assert_not_called()
         mocked_charm_holistic_handler.assert_not_called()
-        assert isinstance(harness.charm.unit.status, WaitingStatus)
 
     def test_when_missing_peer_integration(
         self,
@@ -113,7 +109,6 @@ class TestOpenFGAStoreCreatedEvent:
 
         mocked_workload_service.create_openfga_model.assert_not_called()
         mocked_charm_holistic_handler.assert_not_called()
-        assert isinstance(harness.charm.unit.status, WaitingStatus)
 
     @patch("charm.OpenFGAIntegration.is_store_ready", return_value=False)
     def test_when_openfga_store_not_ready(


### PR DESCRIPTION
This pull request tries to:

- use the `CollectStatusEvent` to centrally manage the charm status. This separates the charm unit status setting from the holistic method
- remove the complex decorators since they are no longer needed