### PR TITLE
chore: fix the oauth tools dep upgraded by renovate

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 ipdb
 juju
-git+https://github.com/canonical/iam-bundle@v0.2.0#egg=oauth_tools
+git+https://github.com/canonical/iam-bundle@oauth_tools-v0.1.0#egg=oauth_tools
 pytest
 pytest-operator==0.35.0
 requests


### PR DESCRIPTION
Found the integration test started to fail from the recent dep upgrades by renovate, see: https://github.com/canonical/identity-platform-admin-ui-operator/actions/runs/10225717561/job/28295076638

Did not find time to check why renovate did this mistaken upgrade for `oauth_tools`. If you know it, please help fix the possible root cause.