### PR TITLE
Update renovate config

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 ipdb
 juju
-git+https://github.com/canonical/iam-bundle@v0.2.0#egg=oauth_tools
+git+https://github.com/canonical/iam-bundle@oauth_tools-v0.1.0#egg=oauth_tools
 pytest
 pytest-operator==0.35.0
 requests

--- a/renovate.json
+++ b/renovate.json
@@ -71,6 +71,13 @@
       "automerge": true,
       "schedule": ["at any time"],
       "additionalBranchPrefix": "auto-"
+    },
+    {
+      "groupName": "renovate pre-commit hooks",
+      "matchSourceUrlPrefixes": ["https://github.com/renovatebot/pre-commit-hooks"],
+      "matchUpdateTypes": ["major"],
+      "schedule": ["at any time"],
+      "additionalBranchPrefix": "auto-"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,7 @@
   ],
   "automergeType": "pr",
   "rebaseWhen": "behind-base-branch",
+  "ignoreDeps": ["iam-bundle"],
   "packageRules": [
     {
       "groupName": "github actions",


### PR DESCRIPTION
This pull request tries to:

- update the renovate config to ignore `iam-bundle` because renovate will try to upgrade it mistakenly
- update the renovate config to upgrade renovate's pre-commit hook only with major updates. This will generate fewer noises. (Renovate releases very frequently)
- restore the `oauth_tools` mistaken upgrade by renovate
