### PR TITLE
chore: remove the renovate config validator pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,3 @@ repos:
   rev: v0.41.0
   hooks:
   - id: markdownlint
-- repo: https://github.com/renovatebot/pre-commit-hooks
-  rev: 38.25.1
-  hooks:
-    - id: renovate-config-validator

--- a/renovate.json
+++ b/renovate.json
@@ -57,15 +57,6 @@
       "additionalBranchPrefix": "auto-"
     },
     {
-      "groupName": "renovate pre-commit hooks",
-      "matchManagers": ["pre-commit"],
-      "matchSourceUrls": ["https://github.com/renovatebot/pre-commit-hooks"],
-      "matchUpdateTypes": ["major"],
-      "automerge": true,
-      "schedule": ["at any time"],
-      "additionalBranchPrefix": "auto-"
-    },
-    {
       "groupName": "pre-commit hooks",
       "matchManagers": ["pre-commit"],
       "matchUpdateTypes": ["major", "minor", "patch"],


### PR DESCRIPTION
Going to remove the renovate config validator pre-commit hook because it introduces more "troubles" than benefits.