### PR TITLE
ci: pin down the httpx version due to the authentication issue with lightkube

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+httpx==0.27.2
 ipdb
 juju
 git+https://github.com/canonical/iam-bundle@oauth_tools-v0.1.1#egg=oauth_tools


### PR DESCRIPTION
### Dependency

The following integration test errors (2 & 3) should be resolved when this [PR](https://github.com/canonical/iam-bundle/pull/307) in iam-bundle is merged.

### Summary

The integration test at the current point has `THREE` errors:

1. The first error is due to the httpx required and used by the lightkube. Recently, httpx released a new version `0.28.0` which breaks the HTTP client authentication to the k8s cluster. The temporary fix is pin down the httpx version. We should also consider using the microk8s kubeconfig in the `oauth_tools`.

```
INFO     pytest_operator.plugin:plugin.py:766 Connecting to existing model github-pr-48ef4-microk8s:testing on unspecified cloud
INFO     oauth_tools.fixtures:fixtures.py:32 Deploying dex resources
INFO     httpx:_client.py:1027 HTTP Request: GET https://10.1.0.27:16443/api/v1/namespaces/dex "HTTP/1.1 401 Unauthorized"
INFO     httpx:_client.py:1027 HTTP Request: GET https://10.1.0.27:16443/api/v1/namespaces/dex/services/dex "HTTP/1.1 401 Unauthorized"
INFO     oauth_tools.external_idp:external_idp.py:121 No service found for identity provider
INFO     httpx:_client.py:1027 HTTP Request: PATCH https://10.1.0.27:16443/api/v1/namespaces/dex?force=true&fieldManager=dex-test "HTTP/1.1 401 Unauthorized"
```

2. The second error from the `test_create_identity_action` test case is due to the fact that the kratos application failed to start. This should be fixed by upgrading the kratos revision used in the `iam-bundle`.

```
tests/integration/test_charm.py::test_create_identity_action FAILED
  File "/home/runner/work/identity-platform-admin-ui-operator/identity-platform-admin-ui-operator/tests/integration/test_charm.py", line 184, in test_create_identity_action
    assert res["identity-id"]
           ~~~^^^^^^^^^^^^^^^
KeyError: 'identity-id'
```

3. The third error comes from the `test_oauth_login_with_identity_bundle ` test case which fails to create the flow. This is also due to the kratos application failure. It should be fixed by upgrading the kratos revision in the `iam-bundle`.

This is the error from login UI:
```
2024-12-03T01:36:38.857Z [login-ui] {"severity":"error","@timestamp":"2024-12-03T01:36:38.857110847Z","message":"failed to create login flow, err: Get \"http://kratos.testing.svc.cluster.local:4433/self-service/login/browser?aal=&login_challenge=evx3b5ACCQ-M3I8zOuPVy3pE2xaUobIxhrzyPKyuBKFzGWJ8ehnuLCexxHzGjtmufwEDPSZ1nagG8hbV4DVSeva-0OLuT27BaAaJyOF5uNmAu7kl4XtKvuE3sZ0COjZM5m5I7iv1LJqCGNxaPcJQYpnXFR8c593AbXZH2tM1x1fGBnZeoj8vefrvtfxc7cqr306ES-zTSn_8wZshaERTeY12THmqhJM-BLX3FcyVzl8elGcRjxHBg3Uq6_ZpwE1NkH6tXVn-u4kw6qiQuy2TCptIiGemDVe6OVfzmLX-l-53EAPeOP-xUY8PiyrSPQs9YUi4n7g1q7rnRO7KQyK1scQDa7z1ZFO5K2OTAmRTW4cN_mDpTNUjvzgbKCe96H1qDSeB4AUF26skIyHmFAtZpsv_8eT3A5n-1QehltC1hbgKK-rNgN0EQVZ0jXNWAeXnHvDFVzLUWBAGJRZFzIYIKttCMIhb3SyvAAujh5hzbVeAQCWtCm-5Ucj-rxHQ4lxGSQHSiHeFtpu7s5wu2GxOL-w4yxx0cJp7dAU-qgSwpGcW77FPLjaNTKl_gC_FAjQdcF644EgmM8q5_cv3gLHP7hKhDzuW8EPPEfLoaA_hS_bOktNXREowwLRThjVe64mkKOstxhd3RihWOzsocOtjSYvYlC8sAzymnPtLy_b5uTHMMfoQ4zl_Gze3-JA2rf6vVl12xXHY4ImFVB7A79uHjpdG4CiMnzH5EEjMkeywEh6hg1QxlFCHtJhTo-HTkjeAapo8hGwydCaMfjKhvQtRQsLI4tFlPI9kKa9jlPpc9vE-kNvxW-EWjLlSB8ki_i9RxfxF3pzu3P9vXeW13TURSRMhzMmNkIR7KodRsgIl0hPnKmPEw-2esg8R8gm4Fi6CyMjCh_p44lKYxqRWW-U4BIVGzmfKNwO-7pr1VkNo3fbFlRekcgn_S6DMtZwjZ-qoNGC2TBaXKZV3boC81uk5uSgEIj1w1kUCM4SAYFWjBh1IEiXuIQ_Nkzw4KS7T9PfAU97Tp6lVbLZ9TTUZ5KCnN2T77sKX3WmVk7ubCUGHg4Ial4rrQuMFo-22ChoGkulOth1C3s01ujcTMzUVu5AGeR3H-ekCl6QnWH5cT5rrEunlfVlFIhR0YEBu4s2o16ZmH8ZizM-vmKiu5J16sMgMe1pSY3GOEbgrcyNEfjGxmUV58kyfWqte_oQ3RGHVMpZUQltK7A1PmeaQ1-P9MXQvsQARdermaU1vH0vYQ_ZakM863aQ4C1iOdjiXGub81UODiljm8wGSLNEi3DSGt8MFkQcL5GyRjAtHOGmFrNW7-LEIk8OQeIAGK6dTQoVlGfemEEFkC_rqNDFhQIv7N911VqZoirehVoJkBFZ3Vp15igDjPvLKE_KUexqtrHNuOZyqUoCm9RrmZSeK8XMULO7Z8pknplmivag2yFXYzO6LqLNftqGkEErGBO0bx9Ion9Cu-Ej-TD2rYZDVbrXFrURBZtZd4eFP4LS3dJeGdF4jCGqJ_SsTT3RFwAv-aGfxBqfvhW8ectRRvOCXi-ZICB-2Bg-tGRnaF7FAV-X5c2CCxcpCXIQXaEnxHesOM-g-ucBhCKFah2BXoF47zJtSVj3Uk_njiBz5_0Ima5ba56SDp-KbuNr0v9n-8KFNbp35TK7YX-af1_eAyR1RZyJkmwU0MZnczJJly61fCjZ19jD9-N9iisKMO8DNLIOWQOmb9VUS8ZEA_EI%3D&refresh=false&return_to=https%3A%2F%2F10.64.140.50%2Ftesting-identity-platform-login-ui-operator%2Fui%2Flogin%3Flogin_challenge%3Devx3b5ACCQ-M3I8zOuPVy3pE2xaUobIxhrzyPKyuBKFzGWJ8ehnuLCexxHzGjtmufwEDPSZ1nagG8hbV4DVSeva-0OLuT27BaAaJyOF5uNmAu7kl4XtKvuE3sZ0COjZM5m5I7iv1LJqCGNxaPcJQYpnXFR8c593AbXZH2tM1x1fGBnZeoj8vefrvtfxc7cqr306ES-zTSn_8wZshaERTeY12THmqhJM-BLX3FcyVzl8elGcRjxHBg3Uq6_ZpwE1NkH6tXVn-u4kw6qiQuy2TCptIiGemDVe6OVfzmLX-l-53EAPeOP-xUY8PiyrSPQs9YUi4n7g1q7rnRO7KQyK1scQDa7z1ZFO5K2OTAmRTW4cN_mDpTNUjvzgbKCe96H1qDSeB4AUF26skIyHmFAtZpsv_8eT3A5n-1QehltC1hbgKK-rNgN0EQVZ0jXNWAeXnHvDFVzLUWBAGJRZFzIYIKttCMIhb3SyvAAujh5hzbVeAQCWtCm-5Ucj-rxHQ4lxGSQHSiHeFtpu7s5wu2GxOL-w4yxx0cJp7dAU-qgSwpGcW77FPLjaNTKl_gC_FAjQdcF644EgmM8q5_cv3gLHP7hKhDzuW8EPPEfLoaA_hS_bOktNXREowwLRThjVe64mkKOstxhd3RihWOzsocOtjSYvYlC8sAzymnPtLy_b5uTHMMfoQ4zl_Gze3-JA2rf6vVl12xXHY4ImFVB7A79uHjpdG4CiMnzH5EEjMkeywEh6hg1QxlFCHtJhTo-HTkjeAapo8hGwydCaMfjKhvQtRQsLI4tFlPI9kKa9jlPpc9vE-kNvxW-EWjLlSB8ki_i9RxfxF3pzu3P9vXeW13TURSRMhzMmNkIR7KodRsgIl0hPnKmPEw-2esg8R8gm4Fi6CyMjCh_p44lKYxqRWW-U4BIVGzmfKNwO-7pr1VkNo3fbFlRekcgn_S6DMtZwjZ-qoNGC2TBaXKZV3boC81uk5uSgEIj1w1kUCM4SAYFWjBh1IEiXuIQ_Nkzw4KS7T9PfAU97Tp6lVbLZ9TTUZ5KCnN2T77sKX3WmVk7ubCUGHg4Ial4rrQuMFo-22ChoGkulOth1C3s01ujcTMzUVu5AGeR3H-ekCl6QnWH5cT5rrEunlfVlFIhR0YEBu4s2o16ZmH8ZizM-vmKiu5J16sMgMe1pSY3GOEbgrcyNEfjGxmUV58kyfWqte_oQ3RGHVMpZUQltK7A1PmeaQ1-P9MXQvsQARdermaU1vH0vYQ_ZakM863aQ4C1iOdjiXGub81UODiljm8wGSLNEi3DSGt8MFkQcL5GyRjAtHOGmFrNW7-LEIk8OQeIAGK6dTQoVlGfemEEFkC_rqNDFhQIv7N911VqZoirehVoJkBFZ3Vp15igDjPvLKE_KUexqtrHNuOZyqUoCm9RrmZSeK8XMULO7Z8pknplmivag2yFXYzO6LqLNftqGkEErGBO0bx9Ion9Cu-Ej-TD2rYZDVbrXFrURBZtZd4eFP4LS3dJeGdF4jCGqJ_SsTT3RFwAv-aGfxBqfvhW8ectRRvOCXi-ZICB-2Bg-tGRnaF7FAV-X5c2CCxcpCXIQXaEnxHesOM-g-ucBhCKFah2BXoF47zJtSVj3Uk_njiBz5_0Ima5ba56SDp-KbuNr0v9n-8KFNbp35TK7YX-af1_eAyR1RZyJkmwU0MZnczJJly61fCjZ19jD9-N9iisKMO8DNLIOWQOmb9VUS8ZEA_EI%253D\": dial tcp 10.152.183.143:4433: connect: connection refused"}
```