### PR TITLE
IAM-1359: address CVEs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,17 +17,10 @@ on:
      - "terraform/**"
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-24.04
-    if: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Install dependencies
-        run: python3 -m pip install tox
-      - name: Run linters
-        run: tox -e lint
-
   tests:
-    name: Run Tests
-    uses: ./.github/workflows/tests.yaml
+    name: CI
+    uses: canonical/identity-team/.github/workflows/charm-pull-request.yaml@v1.7.6
+    with:
+      container-name: "admin-ui"
+      use-charmcraftcache: true
+      node-size: large

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -130,3 +130,4 @@ parts:
     charm-binary-python-packages:
       - jsonschema
       - "pydantic>=2"
+      - "setuptools>=70.0.0"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -214,11 +214,11 @@ async def mail_deployment(ops_test: OpsTest) -> None:
     )
 
     # Wait for the deployment to be ready
-    max_retries = 5
+    max_retries = 10
     for _ in range(max_retries):
         mail_deployment = await client.get(Deployment, name="mail", namespace=ops_test.model_name)
         if not mail_deployment.status.readyReplicas:
-            await asyncio.sleep(5)
+            await asyncio.sleep(10)
             continue
 
         break

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 import asyncio
 import functools
+import os
 import re
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -160,7 +161,12 @@ def admin_service_version() -> str:
 
 @pytest_asyncio.fixture(scope="module")
 async def local_charm(ops_test: OpsTest) -> Path:
-    return await ops_test.build_charm(".")
+    # in GitHub CI, charms are built with charmcraftcache and uploaded to $CHARM_PATH
+    charm = os.getenv("CHARM_PATH")
+    if not charm:
+        # fall back to build locally - required when run outside of GitHub CI
+        charm = await ops_test.build_charm(".")
+    return charm
 
 
 @pytest_asyncio.fixture(scope="module")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -73,7 +73,7 @@ async def test_build_and_deploy(
 
     await ops_test.model.deploy(
         entity_url=OPENFGA_APP,
-        channel="latest/edge",
+        channel="2.0/edge",
         series="jammy",
         trust=True,
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -89,7 +89,7 @@ async def test_build_and_deploy(
 
     await ops_test.model.deploy(
         entity_url=SMTP_INTEGRATOR_APP,
-        channel="latest/stable",
+        channel="latest/edge",
         series="jammy",
         trust=True,
         config={

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,8 @@ commands =
 
 [testenv:integration]
 description = Run integration tests
+pass_env =
+    CHARM_PATH
 deps =
     -r{toxinidir}/integration-requirements.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -68,5 +68,5 @@ pass_env =
 deps =
     -r{toxinidir}/integration-requirements.txt
 commands =
-    playwright install
+    playwright install --with-deps
     pytest -v --tb native {[vars]tst_path}integration --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
- **fix: addressing CVEs related to setupttools**
- **ci: use charmcraftcache for integration tests**


secscan is now happy

```
shipperizer in ~/shipperizer/identity-platform-admin-ui-operator on fix/cve ● ● λ secscan-client --batch submit --scanner trivy --type package --format charm ./identity-platform-admin-ui_ubuntu@22.04-amd64.charm --wait-and-print
Scan request submitted.
Scan request is running.
Scan has succeeded.
Scan request information:
  Started at:        2025-03-27 21:47:06+00:00
  Completed at:      2025-03-27 21:47:08+00:00
  Scanner:           trivy
  Target:            s3://secscan-attachments/35e954bd-aba1-4af2-b874-940d84f79332
  Target type:       package
  Target format:     charm
  Target vulnerabilities:

```