### PR TITLE
fix: not use ops above 2.23.0 at this moment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cosl
 lightkube
-ops >= 2.18.0
+ops < 2.23.0
 pydantic >= 2

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -353,7 +353,7 @@ class TLSCertificates:
             ca = {
                 integration.data[unit]["ca"]
                 for unit in integration.units
-                if "ca" in integration.data[unit]
+                if "ca" in integration.data.get(unit, {})
             }
             ca_certs.update(ca)
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -72,7 +72,7 @@ async def test_build_and_deploy(
 
     await ops_test.model.deploy(
         entity_url=OPENFGA_APP,
-        channel="2.0/edge",
+        channel="latest/edge",
         series="jammy",
         trust=True,
     )


### PR DESCRIPTION
This pull request aims to use `ops` 2.22.0 for now.