### PR TITLE
Migrate integration tests to jubilant

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,86 +1,59 @@
 # Identity Platform Admin UI Operator - AI Coding Instructions
 
-This repository implements a Juju Charm for the [Identity Platform Admin UI](https://github.com/canonical/identity-platform-admin-ui), part of the Canonical Identity Platform. It follows the Canonical Identity Platform's standard charm architecture.
+This repository implements a Juju Charm for the [Identity Platform Admin UI](https://github.com/canonical/identity-platform-admin-ui). It follows the Canonical Identity Platform's standard architecture.
 
-## Project Context & Architecture
+## Architecture & Design Patterns
 
 - **Framework**: Python `ops` framework (Juju).
-- **Target**: Kubernetes (K8s) charm.
-- **Design Pattern**: **Physical Separation & Data Flow**.
+- **Pattern**: **Physical Separation & Data Flow**.
   - **`src/charm.py`**: **Orchestrator**. Handles Juju events, initializes components, and coordinates data flow. Keep this file minimal.
-  - **`src/services.py`**: **Business Logic**. Contains `WorkloadService` (app logic) and `PebbleService` (container management).
-  - **`src/integrations.py`**: **Data Source/Sink**. Wraps relation libraries and handles data transformation for integrations (e.g., `DatabaseConfig`, `OpenFGAIntegration`).
-  - **`src/configs.py`**: **Data Source**. Handles charm configuration and validation.
-  - **`src/utils.py`**: Shared utilities and decorators (e.g., `container_connectivity`, `leader_unit`).
+  - **`src/services.py`**: **Business Logic**. `WorkloadService` (app logic) and `PebbleService` (container management).
+  - **`src/integrations.py`**: **Data Adaptors**. Wraps relation libraries and handles data transformation (e.g., `DatabaseConfig`, `OpenFGAIntegration`).
+  - **`src/configs.py`**: **Configuration**. Handles charm configuration and validation.
+- **Data Flow**: Sources (Config, Relations, Secrets) -> Orchestration (`charm.py`) -> Sinks (Pebble Layer, Relation Databags).
+  - *Do not* pass raw relation data deep into services. Validate/structure it in `integrations.py` first (`dataclass`/`Pydantic`).
 
-### Data Flow Pattern
-Data flows from **Sources** (Config, Relations, Secrets) -> **Orchestration** (`charm.py`) -> **Sinks** (Pebble Layer, Relation Databags).
-- *Do not* pass raw relation data deep into services. Validate and structure it in `integrations.py` first using `dataclass` or `Pydantic` models.
-- **State Management**: Use `PeerData` in `src/integrations.py` to manage state across units (e.g., `COOKIES_ENCRYPTION_KEY`, migration versions).
+## Development Workflows
 
-## Critical Workflows
-
-- **Pre-commit**: This project uses `pre-commit` to enforce standards.
-  - **Formatting**: `tox -e fmt` (runs `isort` and `ruff format`). **Always run this before committing.**
-  - **Linting**: `tox -e lint` (runs `ruff`, `codespell`, `mypy`).
-- **Development Environment**: Use `tox devenv` to create the development virtual environment.
-- **Unit Tests**: `tox -e unit`. Tests are in `tests/unit/`.
-  - Mock `ops.model.Container` and external libraries.
-- **Integration Tests**: `tox -e integration`. Tests are in `tests/integration/`.
-  - Uses `pytest-operator`.
+- **Formatting**: `tox -e fmt` (runs `isort`, `ruff`). **Always run before committing.**
+- **Linting**: `tox -e lint` (runs `ruff`, `codespell`, `mypy`).
+- **Unit Tests**: `tox -e unit`.
+  - **Framework**: `ops.testing` (Scenario).
+  - **Location**: `tests/unit/`.
+  - **Pattern**: Use `ops.testing.Context` and `ops.testing.State` for proper state-transition testing.
+- **Integration Tests**: `tox -e integration`.
+  - **Framework**: `jubilant`.
+  - **Location**: `tests/integration/`.
+  - **Pattern**: Use `jubilant` fixtures for model deployment and assertions.
 - **Build**: `charmcraft pack`.
-- **Library Management**: Files in `lib/charms/` are managed by `charmcraft`. Treat them as **read-only** unless they are explicitly defined and maintained by this repository.
 
 ## Coding Conventions
 
-- **Holistic Handler Pattern**: The charm uses a `_holistic_handler` method in `src/charm.py` to centralize reconciliation logic.
-  - Most event handlers (e.g., `_on_config_changed`, `_on_pebble_ready`, `_on_peer_relation_changed`) should delegate to `_holistic_handler`.
-  - This handler checks preconditions (using `NOOP_CONDITIONS` and `EVENT_DEFER_CONDITIONS`), manages secrets, updates relations, and plans the Pebble layer.
-  - **Status Management**: Unit status is handled separately in `_on_collect_status` (Juju `collect-unit-status` hook), which evaluates the overall state of the charm.
-- **Event Handling**: Limit the use of `event.defer()` as much as possible. Prefer the holistic handler pattern to reconcile state based on current conditions.
-- **Type Hinting**: Strict typing is required. Use `typing.Optional`, `typing.List`, etc.
-- **Docstrings**: Google-style docstrings for all classes and public methods.
-- **Error Handling**: Use custom exceptions in `src/exceptions.py`. Catch them in `charm.py` to set unit status (e.g., `BlockedStatus`).
-- **Observability**:
-  - Use `charms.loki_k8s.v1.loki_push_api` for logging.
-  - Use `charms.prometheus_k8s.v0.prometheus_scrape` for metrics.
-  - Use `charms.tempo_k8s.v2.tracing` for tracing.
-  - Use `charms.grafana_k8s.v0.grafana_dashboard` for dashboards.
-
-## Configuration & Secrets
-
-- **Sensitive Information**: Do not pass sensitive information (e.g., API keys, passwords) directly in charm config. Use **Juju Secrets**.
-- **Resource Management**: Use `KubernetesComputeResourcesPatch` (from `charms.observability_libs.v0.kubernetes_compute_resources_patch`) to handle `cpu` and `memory` configurations.
+- **Holistic Handler**: The charm uses a `_holistic_handler` in `src/charm.py` to centralize reconciliation.
+  - Delegates events (config/relation changes) to this handler.
+  - Checks preconditions (`NOOP_CONDITIONS`), manages secrets, updates relations, and plans Pebble layer.
+- **Status Management**: Unit status handled in `_on_collect_status`.
+- **State Management**: Use `PeerData` in `src/integrations.py` for cross-unit state (e.g., migration versions).
+- **Error Handling**: Use custom exceptions in `src/exceptions.py`. Catch in `charm.py` to set status (e.g., `BlockedStatus`).
+- **Secrets**: Use Juju Secrets for sensitive info, never charm config.
 
 ## Integration Points
 
-- **Database**: `pg-database` (PostgreSQL) - managed via `DatabaseRequires` and `DatabaseConfig`.
+- **Database**: PostgreSQL (`pg-database`) via `DatabaseRequires`.
 - **Identity**: `hydra-endpoint-info`, `kratos-info`, `openfga`, `oauth`.
-- **Ingress**: `ingress` (Traefik) - managed via `IngressPerAppRequirer`.
-- **Certificates**: `receive-ca-cert` - managed via `CertificateTransferRequires`.
-- **SMTP**: `smtp` - managed via `SmtpRequires`.
+- **Ingress**: Traefik (`ingress`) via `IngressPerAppRequirer`.
+- **Certificates**: `receive-ca-cert` via `CertificateTransferRequires`.
+- **Observability**: Loki (`log-proxy`), Prometheus (`metrics-endpoint`), Tempo (`tracing`).
 
 ## Database Migrations
 
-- **Actions**: The charm implements `run-migration-up`, `run-migration-down`, and `run-migration-status` actions.
-- **Logic**: Migration logic resides in `src/charm.py` (action handlers) and `src/services.py` (CLI execution).
-- **State**: Migration version is tracked in peer relation data (`PeerData`).
+- **Actions**: `run-migration-up`, `run-migration-down`.
+- **Logic**: Handled in `src/charm.py` (actions) and `src/services.py` (CLI).
+- **State**: Migration version tracked in `PeerData`.
 
-## Debugging Deployments
+## Debugging
 
-When debugging deployment issues, follow this structured approach. **Note**: The MCP server tools are preferred for their integration, but if the MCP server is unavailable, use the standard CLI commands provided as alternatives.
-
-1. **Check Model Status**: Use the MCP server (`get_status`) or `juju status` to identify blocked or waiting units.
-   - Look for status messages indicating missing dependencies or check failures (e.g., "Migration check failed").
-2. **Inspect Juju Logs**: Use the MCP server (`get_debug_log`) or `juju debug-log` to find specific error messages from the charm code.
-   - Look for Python exceptions or non-zero exit codes from subprocess calls.
-3. **Inspect Workload Logs**: Use the MCP server (`get_workload_logs`) or `kubectl logs` (via terminal) to check the application's standard output/error.
-   - This helps identify application startup issues that the charm might not catch immediately.
-4. **Verify Workload Environment**: Use `kubectl exec` to run commands inside the container.
-   - Verify the application version (`<app-binary> version`).
-   - Verify available commands (`<app-binary> --help`).
-   - Check for missing files or permissions.
-
-## Continuous Improvement
-
-- **Instruction Maintenance**: As you work on the codebase, if you identify new patterns, best practices, or recurring issues that are not covered here, **you must update this file**. This ensures that the instructions remain relevant and helpful for future tasks.
+1. **Model Status**: `juju status` for blocked/waiting units.
+2. **Juju Logs**: `juju debug-log` for Python exceptions.
+3. **Workload Logs**: `kubectl logs` for app startup issues.
+4. **Environment**: `kubectl exec` to verify binary versions and files.

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-ipdb
-juju
-git+https://github.com/canonical/iam-bundle@oauth_tools-v0.1.2#egg=oauth_tools
+jubilant
 pytest
-pytest-operator==0.43.1
+requests
+playwright
+tenacity

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
-pythonpath = ["src", "lib"]
+pythonpath = ["src", "lib", "tests"]
 
 # Linting and formatting tools configuration
 [tool.codespell]
@@ -87,8 +87,7 @@ ignore_missing_imports = true
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]
-module = ["ops.*", "pytest.*", "pytest_operator.*", "urllib3.*", "jinja2.*", "lightkube.*", "pytest_mock.*"]
+module = ["ops.*", "pytest.*", "urllib3.*", "jinja2.*", "lightkube.*", "pytest_mock.*"]
 
 [tool.pyright]
 extraPaths = ["src", "lib"]
-exclude = ["tests/integration"]

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,7 +3,7 @@
 
 """Constants for the charm."""
 
-from pathlib import PurePath
+from pathlib import Path, PurePath
 from string import Template
 
 # Charm constants
@@ -24,6 +24,8 @@ OAUTH_SCOPES = "openid,email,profile,offline_access"
 OAUTH_GRANT_TYPES = ["authorization_code", "refresh_token"]
 OAUTH_CALLBACK_PATH = "api/v0/auth/callback"
 DEFAULT_ACCESS_TOKEN_VERIFICATION_STRATEGY = "userinfo"
+CA_BUNDLE_PATH = Path("/etc/ssl/certs/ca-certificates.crt")
+INTEGRATION_CA_BUNDLE_PATH = Path("/usr/local/share/ca-certificates/ca-certificates.crt")
 
 # Integration constants
 DATABASE_INTEGRATION_NAME = "pg-database"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,20 +1,38 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-import asyncio
-import functools
+
 import os
 import re
-from contextlib import asynccontextmanager
+import secrets
+import subprocess
+from contextlib import suppress
 from pathlib import Path
-from typing import AsyncGenerator, Callable, Optional
+from time import sleep
+from typing import Callable, Generator
 
+import jubilant
 import pytest
-import pytest_asyncio
-import yaml
-from juju.application import Application
-from juju.unit import Unit
-from lightkube import AsyncClient
-from lightkube.config.kubeconfig import KubeConfig
+from integration.constants import (
+    ADMIN_SERVICE_APP,
+    ADMIN_SERVICE_IMAGE,
+    CERTIFICATE_TRANSFER_INTEGRATION_NAME,
+    DATABASE_INTEGRATION_NAME,
+    DB_APP,
+    HYDRA_ENDPOINTS_INTEGRATION_NAME,
+    INGRESS_INTEGRATION_NAME,
+    KRATOS_INFO_INTEGRATION_NAME,
+    MAIL_HTTP_PORT,
+    MAIL_IMAGE,
+    MAIL_SMTP_PORT,
+    OPENFGA_APP,
+    OPENFGA_INTEGRATION_NAME,
+    SMTP_INTEGRATOR_APP,
+)
+from integration.utils import (
+    get_app_integration_data,
+    juju_model_factory,
+)
+from lightkube import Client, KubeConfig
 from lightkube.models.apps_v1 import DeploymentSpec
 from lightkube.models.core_v1 import (
     Container,
@@ -27,129 +45,180 @@ from lightkube.models.core_v1 import (
 from lightkube.models.meta_v1 import LabelSelector, ObjectMeta
 from lightkube.resources.apps_v1 import Deployment
 from lightkube.resources.core_v1 import Service
-from pytest_operator.plugin import OpsTest
-
-METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
-ADMIN_SERVICE_APP = METADATA["name"]
-ADMIN_SERVICE_IMAGE = METADATA["resources"]["oci-image"]["upstream-source"]
-DB_APP = "postgresql-k8s"
-OPENFGA_APP = "openfga-k8s"
-SMTP_INTEGRATOR_APP = "smtp-integrator"
-MAIL_APP = "mail"
-MAIL_IMAGE = "mailhog/mailhog:latest"
-MAIL_SMTP_PORT = 1025
-MAIL_HTTP_PORT = 8025
 
 
-async def integrate_dependencies(
-    ops_test: OpsTest,
-    request: pytest.FixtureRequest,
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--keep-models",
+        "--no-teardown",
+        action="store_true",
+        dest="no_teardown",
+        default=False,
+        help="Keep the model after the test is finished.",
+    )
+    parser.addoption(
+        "--model",
+        action="store",
+        dest="model",
+        default=None,
+        help="The model to run the tests on.",
+    )
+    parser.addoption(
+        "--no-deploy",
+        "--no-setup",
+        action="store_true",
+        dest="no_setup",
+        default=False,
+        help="Skip deployment of the charm.",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "setup: tests that setup some parts of the environment")
+    config.addinivalue_line("markers", "upgrade: tests that upgrade the charm")
+    config.addinivalue_line(
+        "markers", "teardown: tests that teardown some parts of the environment."
+    )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    skip_setup = pytest.mark.skip(reason="no_setup provided")
+    skip_teardown = pytest.mark.skip(reason="no_teardown provided")
+    for item in items:
+        if config.getoption("no_setup") and "setup" in item.keywords:
+            item.add_marker(skip_setup)
+        if config.getoption("no_teardown") and "teardown" in item.keywords:
+            item.add_marker(skip_teardown)
+
+
+@pytest.fixture(scope="module")
+def juju(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]:
+    """Create a temporary Juju model for integration tests."""
+    model_name = request.config.getoption("--model")
+    if not model_name:
+        model_name = f"test-admin-ui-{secrets.token_hex(4)}"
+
+    juju_ = juju_model_factory(model_name)
+    juju_.wait_timeout = 10 * 60
+
+    try:
+        yield juju_
+    finally:
+        if request.session.testsfailed:
+            log = juju_.debug_log(limit=1000)
+            print(log, end="")
+
+        no_teardown = bool(request.config.getoption("--no-teardown"))
+        keep_model = no_teardown or request.session.testsfailed > 0
+        if not keep_model:
+            with suppress(jubilant.CLIError):
+                args = [
+                    "destroy-model",
+                    juju_.model,
+                    "--no-prompt",
+                    "--destroy-storage",
+                    "--force",
+                    "--timeout",
+                    "600s",
+                ]
+                juju_.cli(*args, include_model=False)
+
+
+@pytest.fixture(scope="session")
+def local_charm() -> Path:
+    """Get the path to the charm-under-test."""
+    charm: str | Path | None = os.getenv("CHARM_PATH")
+    if not charm:
+        subprocess.run(["charmcraft", "pack"], check=True)
+        if not (charms := list(Path(".").glob("*.charm"))):
+            raise RuntimeError("Charm not found and build failed")
+        charm = charms[0].absolute()
+    return Path(charm)
+
+
+def integrate_dependencies(
+    juju: jubilant.Juju,
+    kratos_app_name: str,
+    hydra_app_name: str,
+    public_ingress_name: str,
+    self_signed_certificates_app_name: str,
 ) -> None:
-    kratos_app_name = request.getfixturevalue("kratos_app_name")
-    hydra_app_name = request.getfixturevalue("hydra_app_name")
-    public_ingress_name = request.getfixturevalue("public_traefik_app_name")
-    self_signed_cert_app_name = request.getfixturevalue("self_signed_certificates_app_name")
-
-    await ops_test.model.integrate(
-        f"{ADMIN_SERVICE_APP}:kratos-info",
-        kratos_app_name,
+    juju.integrate(f"{ADMIN_SERVICE_APP}:{DATABASE_INTEGRATION_NAME}", DB_APP)
+    juju.integrate(
+        f"{ADMIN_SERVICE_APP}:{KRATOS_INFO_INTEGRATION_NAME}",
+        f"{kratos_app_name}:{KRATOS_INFO_INTEGRATION_NAME}",
     )
-    await ops_test.model.integrate(
-        f"{ADMIN_SERVICE_APP}:hydra-endpoint-info",
-        hydra_app_name,
+    juju.integrate(
+        f"{ADMIN_SERVICE_APP}:{HYDRA_ENDPOINTS_INTEGRATION_NAME}",
+        f"{hydra_app_name}:{HYDRA_ENDPOINTS_INTEGRATION_NAME}",
     )
-    await ops_test.model.integrate(ADMIN_SERVICE_APP, DB_APP)
-    await ops_test.model.integrate(f"{ADMIN_SERVICE_APP}:openfga", f"{OPENFGA_APP}:openfga")
-    await ops_test.model.integrate(ADMIN_SERVICE_APP, public_ingress_name)
-    await ops_test.model.integrate(f"{ADMIN_SERVICE_APP}:oauth", hydra_app_name)
-    await ops_test.model.integrate(ADMIN_SERVICE_APP, self_signed_cert_app_name)
-    await ops_test.model.integrate(f"{ADMIN_SERVICE_APP}:smtp", f"{SMTP_INTEGRATOR_APP}:smtp")
-
-
-async def get_unit_data(ops_test: OpsTest, unit_name: str) -> dict:
-    show_unit_cmd = f"show-unit {unit_name}".split()
-    _, stdout, _ = await ops_test.juju(*show_unit_cmd)
-    cmd_output = yaml.safe_load(stdout)
-    return cmd_output[unit_name]
-
-
-async def get_integration_data(
-    ops_test: OpsTest, app_name: str, integration_name: str, unit_num: int = 0
-) -> Optional[dict]:
-    data = await get_unit_data(ops_test, f"{app_name}/{unit_num}")
-    return next(
-        (
-            integration
-            for integration in data["relation-info"]
-            if integration["endpoint"] == integration_name
-        ),
-        None,
+    juju.integrate(f"{ADMIN_SERVICE_APP}:oauth", f"{hydra_app_name}:oauth")
+    juju.integrate(
+        f"{ADMIN_SERVICE_APP}:{INGRESS_INTEGRATION_NAME}",
+        f"{public_ingress_name}:{INGRESS_INTEGRATION_NAME}",
     )
-
-
-async def get_app_integration_data(
-    ops_test: OpsTest,
-    app_name: str,
-    integration_name: str,
-    unit_num: int = 0,
-) -> Optional[dict]:
-    data = await get_integration_data(ops_test, app_name, integration_name, unit_num)
-    return data["application-data"] if data else None
-
-
-@pytest_asyncio.fixture
-async def app_integration_data(ops_test: OpsTest) -> Callable:
-    return functools.partial(get_app_integration_data, ops_test)
-
-
-@pytest_asyncio.fixture
-async def leader_kratos_integration_data(app_integration_data: Callable) -> Optional[dict]:
-    return await app_integration_data(ADMIN_SERVICE_APP, "kratos-info")
-
-
-@pytest_asyncio.fixture
-async def leader_hydra_endpoint_integration_data(app_integration_data: Callable) -> Optional[dict]:
-    return await app_integration_data(ADMIN_SERVICE_APP, "hydra-endpoint-info")
-
-
-@pytest_asyncio.fixture
-async def leader_openfga_integration_data(app_integration_data: Callable) -> Optional[dict]:
-    return await app_integration_data(ADMIN_SERVICE_APP, "openfga")
-
-
-@pytest_asyncio.fixture
-async def leader_ingress_integration_data(app_integration_data: Callable) -> Optional[dict]:
-    return await app_integration_data(ADMIN_SERVICE_APP, "ingress")
-
-
-@pytest_asyncio.fixture
-async def leader_peer_integration_data(app_integration_data: Callable) -> Optional[dict]:
-    return await app_integration_data(ADMIN_SERVICE_APP, ADMIN_SERVICE_APP)
-
-
-@pytest_asyncio.fixture
-async def leader_oauth_integration_data(app_integration_data: Callable) -> Optional[dict]:
-    return await app_integration_data(ADMIN_SERVICE_APP, "oauth")
-
-
-@pytest_asyncio.fixture
-async def leader_smtp_integration_data(app_integration_data: Callable) -> Optional[dict]:
-    return await app_integration_data(ADMIN_SERVICE_APP, "smtp")
-
-
-@pytest_asyncio.fixture
-async def leader_database_integration_data(app_integration_data: Callable) -> Optional[dict]:
-    return await app_integration_data(ADMIN_SERVICE_APP, "pg-database")
+    juju.integrate(f"{ADMIN_SERVICE_APP}:{OPENFGA_INTEGRATION_NAME}", OPENFGA_APP)
+    juju.integrate(
+        f"{ADMIN_SERVICE_APP}:{CERTIFICATE_TRANSFER_INTEGRATION_NAME}",
+        self_signed_certificates_app_name,
+    )
+    juju.integrate(ADMIN_SERVICE_APP, f"{SMTP_INTEGRATOR_APP}:smtp")
 
 
 @pytest.fixture
-def admin_service_application(ops_test: OpsTest) -> Application:
-    return ops_test.model.applications[ADMIN_SERVICE_APP]
+def app_integration_data(juju: jubilant.Juju) -> Callable:
+    def _get_data(app_name: str, integration_name: str, unit_num: int = 0):
+        return get_app_integration_data(juju, app_name, integration_name, unit_num)
+
+    return _get_data
 
 
 @pytest.fixture
-def admin_service_unit(admin_service_application: Application) -> Unit:
-    return admin_service_application.units[0]
+def leader_kratos_integration_data(
+    app_integration_data: Callable, kratos_app_name: str
+) -> dict | None:
+    return app_integration_data(ADMIN_SERVICE_APP, KRATOS_INFO_INTEGRATION_NAME)
+
+
+@pytest.fixture
+def leader_hydra_endpoint_integration_data(
+    app_integration_data: Callable, hydra_app_name: str
+) -> dict | None:
+    return app_integration_data(ADMIN_SERVICE_APP, HYDRA_ENDPOINTS_INTEGRATION_NAME)
+
+
+@pytest.fixture
+def leader_openfga_integration_data(app_integration_data: Callable) -> dict | None:
+    return app_integration_data(ADMIN_SERVICE_APP, OPENFGA_INTEGRATION_NAME)
+
+
+@pytest.fixture
+def leader_ingress_integration_data(
+    app_integration_data: Callable, public_traefik_app_name: str
+) -> dict | None:
+    return app_integration_data(ADMIN_SERVICE_APP, INGRESS_INTEGRATION_NAME)
+
+
+@pytest.fixture
+def leader_oauth_integration_data(
+    app_integration_data: Callable, hydra_app_name: str
+) -> dict | None:
+    return app_integration_data(ADMIN_SERVICE_APP, "oauth")
+
+
+@pytest.fixture
+def leader_peer_integration_data(app_integration_data: Callable) -> dict | None:
+    return app_integration_data(ADMIN_SERVICE_APP, ADMIN_SERVICE_APP)
+
+
+@pytest.fixture
+def leader_smtp_integration_data(app_integration_data: Callable) -> dict | None:
+    return app_integration_data(ADMIN_SERVICE_APP, "smtp")
+
+
+@pytest.fixture
+def leader_database_integration_data(app_integration_data: Callable) -> dict | None:
+    return app_integration_data(ADMIN_SERVICE_APP, DATABASE_INTEGRATION_NAME)
 
 
 @pytest.fixture(scope="session")
@@ -158,22 +227,12 @@ def admin_service_version() -> str:
     return matched.group("version") if matched else ""
 
 
-@pytest_asyncio.fixture(scope="module")
-async def local_charm(ops_test: OpsTest) -> str:
-    # in GitHub CI, charms are built with charmcraftcache and uploaded to $CHARM_PATH
-    charm = os.getenv("CHARM_PATH")
-    if not charm:
-        # fall back to build locally - required when run outside of GitHub CI
-        charm = await ops_test.build_charm(".")
-    return str(charm)
-
-
-@pytest_asyncio.fixture(scope="module")
-async def mail_deployment(ops_test: OpsTest) -> None:
-    client = AsyncClient(config=KubeConfig.from_file("~/.kube/config"))
+@pytest.fixture(scope="module")
+def mail_deployment(juju: jubilant.Juju) -> None:
+    client = Client(config=KubeConfig.from_file("~/.kube/config"))
 
     deployment = Deployment(
-        metadata=ObjectMeta(name="mail", namespace=ops_test.model_name),
+        metadata=ObjectMeta(name="mail", namespace=juju.model),
         spec=DeploymentSpec(
             replicas=1,
             selector=LabelSelector(matchLabels={"app": "mail"}),
@@ -196,7 +255,7 @@ async def mail_deployment(ops_test: OpsTest) -> None:
     )
 
     service = Service(
-        metadata=ObjectMeta(name="mail", namespace=ops_test.model_name),
+        metadata=ObjectMeta(name="mail", namespace=juju.model),
         spec=ServiceSpec(
             ports=[
                 ServicePort(port=MAIL_SMTP_PORT, targetPort=MAIL_SMTP_PORT, name="smtp"),
@@ -207,42 +266,47 @@ async def mail_deployment(ops_test: OpsTest) -> None:
     )
 
     # Apply the resources
-    await asyncio.gather(
-        client.apply(deployment, field_manager="mail"),
-        client.apply(service, namespace=ops_test.model_name, field_manager="mail"),
-    )
+    client.apply(deployment, field_manager="mail")
+    client.apply(service, namespace=juju.model, field_manager="mail")
 
     # Wait for the deployment to be ready
     max_retries = 10
     for _ in range(max_retries):
-        mail_deployment = await client.get(Deployment, name="mail", namespace=ops_test.model_name)
-        if not mail_deployment.status.readyReplicas:
-            await asyncio.sleep(10)
+        mail_deployment = client.get(Deployment, name="mail", namespace=juju.model)
+        if not mail_deployment.status or not mail_deployment.status.readyReplicas:
+            sleep(10)
             continue
-
         break
     else:
         raise TimeoutError(f"Mail service not ready after {max_retries} retries.")
 
 
-@asynccontextmanager
-async def remove_integration(
-    ops_test: OpsTest, remote_app_name: str, integration_name: str
-) -> AsyncGenerator[None, None]:
-    remove_integration_cmd = (
-        f"remove-relation {ADMIN_SERVICE_APP}:{integration_name} {remote_app_name}"
-    ).split()
-    await ops_test.juju(*remove_integration_cmd)
-    await ops_test.model.wait_for_idle(
-        apps=[remote_app_name],
-        status="active",
-    )
+# Fixture to provide app names that are usually in bundle
+@pytest.fixture(scope="module")
+def openfga_app_name() -> str:
+    return OPENFGA_APP
 
-    try:
-        yield
-    finally:
-        await ops_test.model.integrate(f"{ADMIN_SERVICE_APP}:{integration_name}", remote_app_name)
-        await ops_test.model.wait_for_idle(
-            apps=[ADMIN_SERVICE_APP, remote_app_name],
-            status="active",
-        )
+
+@pytest.fixture(scope="module")
+def db_app_name() -> str:
+    return DB_APP
+
+
+@pytest.fixture(scope="module")
+def kratos_app_name() -> str:
+    return "kratos"
+
+
+@pytest.fixture(scope="module")
+def hydra_app_name() -> str:
+    return "hydra"
+
+
+@pytest.fixture(scope="module")
+def public_traefik_app_name() -> str:
+    return "traefik-public"
+
+
+@pytest.fixture(scope="module")
+def self_signed_certificates_app_name() -> str:
+    return "self-signed-certificates"

--- a/tests/integration/constants.py
+++ b/tests/integration/constants.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from pathlib import Path
+
+import yaml
+
+METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+ADMIN_SERVICE_APP: str = METADATA["name"]
+ADMIN_SERVICE_IMAGE = METADATA["resources"]["oci-image"]["upstream-source"]
+DB_APP = "postgresql-k8s"
+OPENFGA_APP = "openfga-k8s"
+SMTP_INTEGRATOR_APP = "smtp-integrator"
+MAIL_APP = "mail"
+MAIL_IMAGE = "mailhog/mailhog:latest"
+MAIL_SMTP_PORT = 1025
+MAIL_HTTP_PORT = 8025
+
+# Constants for integration names
+CERTIFICATE_TRANSFER_INTEGRATION_NAME = "receive-ca-cert"
+DATABASE_INTEGRATION_NAME = "pg-database"
+HYDRA_ENDPOINTS_INTEGRATION_NAME = "hydra-endpoint-info"
+INGRESS_INTEGRATION_NAME = "ingress"
+KRATOS_INFO_INTEGRATION_NAME = "kratos-info"
+OPENFGA_INTEGRATION_NAME = "openfga"
+OPENFGA_MODEL_ID = "openfga_model_id"

--- a/tests/integration/identity_bundle.yaml
+++ b/tests/integration/identity_bundle.yaml
@@ -8,33 +8,18 @@ issues: https://github.com/canonical/iam-bundle/issues
 applications:
   hydra:
     charm: hydra
-    revision: 339
-    resources:
-      oci-image: ghcr.io/canonical/hydra:2.3.0-canonical
     channel: latest/edge
     scale: 1
     series: jammy
     trust: true
   kratos:
     charm: kratos
-    revision: 500
-    resources:
-      oci-image: ghcr.io/canonical/kratos:1.3.1
     channel: latest/edge
     scale: 1
     series: jammy
     trust: true
-  kratos-external-idp-integrator:
-    charm: kratos-external-idp-integrator
-    channel: latest/edge
-    revision: 245
-    scale: 1
-    series: jammy
   identity-platform-login-ui-operator:
     charm: identity-platform-login-ui-operator
-    revision: 146
-    resources:
-      oci-image: ghcr.io/canonical/identity-platform-login-ui:v0.21.2
     channel: latest/edge
     scale: 1
     series: jammy
@@ -42,8 +27,6 @@ applications:
   postgresql-k8s:
     charm: postgresql-k8s
     channel: 14/stable
-    resources:
-      postgresql-image: ghcr.io/canonical/charmed-postgresql@sha256:e2283194f7f8d9997fb06f0fd1ab0ec3938ce73ac001133bd8fd393ebe83acc7
     series: jammy
     scale: 1
     trust: true
@@ -52,40 +35,22 @@ applications:
       plugin_btree_gin_enable: true
   self-signed-certificates:
     charm: self-signed-certificates
-    revision: 155
-    channel: latest/stable
+    channel: 1/stable
     scale: 1
-  traefik-admin:
-    charm: traefik-k8s
-    channel: latest/stable
-    revision: 176
-    resources:
-      traefik-image: docker.io/ubuntu/traefik:2-22.04
-    series: focal
-    scale: 1
-    trust: true
   traefik-public:
     charm: traefik-k8s
-    channel: latest/stable
-    revision: 176
-    resources:
-      traefik-image: docker.io/ubuntu/traefik:2-22.04
-    series: focal
+    channel: latest/edge
     scale: 1
     trust: true
 relations:
   - [hydra:pg-database, postgresql-k8s:database]
   - [kratos:pg-database, postgresql-k8s:database]
   - [kratos:hydra-endpoint-info, hydra:hydra-endpoint-info]
-  - [kratos-external-idp-integrator:kratos-external-idp, kratos:kratos-external-idp]
-  - [hydra:admin-ingress, traefik-admin:ingress]
-  - [hydra:public-ingress, traefik-public:ingress]
-  - [kratos:admin-ingress, traefik-admin:ingress]
-  - [kratos:public-ingress, traefik-public:ingress]
-  - [identity-platform-login-ui-operator:ingress, traefik-public:ingress]
+  - [hydra:public-route, traefik-public:traefik-route]
+  - [kratos:public-route, traefik-public:traefik-route]
+  - [identity-platform-login-ui-operator:public-route, traefik-public:traefik-route]
   - [identity-platform-login-ui-operator:hydra-endpoint-info, hydra:hydra-endpoint-info]
   - [identity-platform-login-ui-operator:ui-endpoint-info, hydra:ui-endpoint-info]
   - [identity-platform-login-ui-operator:ui-endpoint-info, kratos:ui-endpoint-info]
   - [identity-platform-login-ui-operator:kratos-info, kratos:kratos-info]
-  - [traefik-admin:certificates, self-signed-certificates:certificates]
   - [traefik-public:certificates, self-signed-certificates:certificates]

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import jubilant
+import pytest
+from integration.constants import (
+    ADMIN_SERVICE_APP,
+    ADMIN_SERVICE_IMAGE,
+    CERTIFICATE_TRANSFER_INTEGRATION_NAME,
+    DATABASE_INTEGRATION_NAME,
+    HYDRA_ENDPOINTS_INTEGRATION_NAME,
+    INGRESS_INTEGRATION_NAME,
+    KRATOS_INFO_INTEGRATION_NAME,
+    OPENFGA_INTEGRATION_NAME,
+)
+from integration.utils import all_active, any_error
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.skip
+@pytest.mark.upgrade
+class TestUpgrade:
+    admin_ui_app_name = "admin-ui-upgrade"
+    hydra_app_name = "hydra-upgrade"
+    kratos_app_name = "kratos-upgrade"
+    db_app_name = "postgres-upgrade"
+    login_ui_app_name = "login-ui-upgrade"
+    openfga_app_name = "openfga-upgrade"
+    self_signed_certificates_app_name = "self-signed-certificates-upgrade"
+    public_traefik_app_name = "traefik-public-upgrade"
+    smtp_integrator_app_name = "smtp-integrator-upgrade"
+
+    def integrate_dependencies(self, juju: jubilant.Juju) -> None:
+        juju.integrate(f"{self.hydra_app_name}:pg-database", f"{self.db_app_name}:database")
+        juju.integrate(f"{self.kratos_app_name}:pg-database", f"{self.db_app_name}:database")
+        juju.integrate(f"{self.kratos_app_name}:hydra-endpoint-info", f"{self.hydra_app_name}:hydra-endpoint-info")
+        juju.integrate(f"{self.hydra_app_name}:public-ingress", f"{self.public_traefik_app_name}:ingress")
+        juju.integrate(f"{self.kratos_app_name}:public-ingress", f"{self.public_traefik_app_name}:ingress")
+        juju.integrate(f"{self.login_ui_app_name}:ingress", f"{self.public_traefik_app_name}:ingress")
+        juju.integrate(f"{self.login_ui_app_name}:hydra-endpoint-info", f"{self.hydra_app_name}:hydra-endpoint-info")
+        juju.integrate(f"{self.login_ui_app_name}:ui-endpoint-info", f"{self.hydra_app_name}:ui-endpoint-info")
+        juju.integrate(f"{self.login_ui_app_name}:ui-endpoint-info", f"{self.kratos_app_name}:ui-endpoint-info")
+        juju.integrate(f"{self.login_ui_app_name}:kratos-info", f"{self.kratos_app_name}:kratos-info")
+        juju.integrate(f"{self.public_traefik_app_name}:certificates", f"{self.self_signed_certificates_app_name}:certificates")
+        juju.integrate(f"{self.admin_ui_app_name}:{DATABASE_INTEGRATION_NAME}", self.db_app_name)
+        juju.integrate(
+            f"{self.admin_ui_app_name}:{KRATOS_INFO_INTEGRATION_NAME}",
+            f"{self.kratos_app_name}:{KRATOS_INFO_INTEGRATION_NAME}",
+        )
+        juju.integrate(
+            f"{self.admin_ui_app_name}:{HYDRA_ENDPOINTS_INTEGRATION_NAME}",
+            f"{self.hydra_app_name}:{HYDRA_ENDPOINTS_INTEGRATION_NAME}",
+        )
+        juju.integrate(f"{self.admin_ui_app_name}:oauth", f"{self.hydra_app_name}:oauth")
+        juju.integrate(
+            f"{self.admin_ui_app_name}:{INGRESS_INTEGRATION_NAME}",
+            f"{self.public_traefik_app_name}:{INGRESS_INTEGRATION_NAME}",
+        )
+        juju.integrate(
+            f"{self.admin_ui_app_name}:{OPENFGA_INTEGRATION_NAME}", self.openfga_app_name
+        )
+        juju.integrate(
+            f"{self.admin_ui_app_name}:{CERTIFICATE_TRANSFER_INTEGRATION_NAME}",
+            self.self_signed_certificates_app_name,
+        )
+        juju.integrate(self.admin_ui_app_name, f"{self.smtp_integrator_app_name}:smtp")
+
+    def test_deploy_hydra_from_charmhub(self, juju: jubilant.Juju, mail_deployment: None) -> None:
+        juju.deploy(
+            f"ch:{ADMIN_SERVICE_APP}",
+            app=self.admin_ui_app_name,
+            channel="latest/edge",
+            trust=True,
+        )
+        juju.deploy(
+            "hydra",
+            app=self.hydra_app_name,
+            channel="latest/stable",
+            trust=True,
+        )
+        juju.deploy(
+            "identity-platform-login-ui-operator",
+            app=self.login_ui_app_name,
+            channel="latest/stable",
+            trust=True,
+        )
+        juju.deploy(
+            "kratos",
+            app=self.kratos_app_name,
+            channel="latest/stable",
+            trust=True,
+        )
+        juju.deploy(
+            "postgresql-k8s",
+            app=self.db_app_name,
+            channel="latest/stable",
+            trust=True,
+        )
+        juju.deploy(
+            "openfga",
+            app=self.openfga_app_name,
+            channel="latest/stable",
+            trust=True,
+        )
+        juju.deploy(
+            "self-signed-certificates",
+            app=self.self_signed_certificates_app_name,
+            channel="latest/stable",
+            trust=True,
+        )
+        juju.deploy(
+            "traefik",
+            app=self.public_traefik_app_name,
+            channel="latest/stable",
+            trust=True,
+        )
+        juju.deploy(
+            "smtp-integrator",
+            app=self.smtp_integrator_app_name,
+            channel="latest/stable",
+            trust=True,
+        )
+
+        # integrate with dependencies
+        self.integrate_dependencies(juju)
+
+        juju.wait(
+            ready=all_active(
+                self.openfga_app_name,
+                self.db_app_name,
+                self.smtp_integrator_app_name,
+                self.kratos_app_name,
+                self.hydra_app_name,
+                self.public_traefik_app_name,
+                self.self_signed_certificates_app_name,
+            ),
+            error=any_error(
+                self.openfga_app_name,
+                self.db_app_name,
+                self.smtp_integrator_app_name,
+                self.kratos_app_name,
+                self.hydra_app_name,
+                self.public_traefik_app_name,
+                self.self_signed_certificates_app_name,
+            ),
+            timeout=20 * 60,
+        )
+
+        juju.wait(
+            ready=all_active(
+                self.admin_ui_app_name,
+            ),
+            error=any_error(
+                self.admin_ui_app_name,
+            ),
+            timeout=5 * 60,
+        )
+
+    def test_upgrade(self, juju: jubilant.Juju, local_charm: str) -> None:
+        juju.refresh(
+            self.admin_ui_app_name,
+            path=str(local_charm),
+            resources={"oci-image": ADMIN_SERVICE_IMAGE},
+        )
+
+        juju.wait(
+            ready=all_active(ADMIN_SERVICE_APP),
+            error=any_error(ADMIN_SERVICE_APP),
+            timeout=5 * 60,
+        )

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,0 +1,127 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from contextlib import contextmanager
+from typing import Callable, Iterator
+
+import jubilant
+import yaml
+from integration.constants import ADMIN_SERVICE_APP
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+StatusPredicate = Callable[[jubilant.Status], bool]
+
+
+def juju_model_factory(model_name: str) -> jubilant.Juju:
+    juju = jubilant.Juju()
+    try:
+        juju.add_model(model_name, config={"logging-config": "<root>=INFO"})
+    except jubilant.CLIError as e:
+        if "already exists" not in e.stderr:
+            raise
+
+    juju.model = model_name
+
+    return juju
+
+
+def get_unit_data(model: jubilant.Juju, unit_name: str) -> dict:
+    """Get the data for a given unit."""
+    stdout = model.cli("show-unit", unit_name)
+    cmd_output = yaml.safe_load(stdout)
+    return cmd_output[unit_name]
+
+
+def get_integration_data(
+    juju: jubilant.Juju, app_name: str, integration_name: str, unit_num: int = 0
+) -> dict | None:
+    """Get the integration data for a given integration."""
+    data = get_unit_data(juju, f"{app_name}/{unit_num}")
+    return next(
+        (
+            integration
+            for integration in data["relation-info"]
+            if integration["endpoint"] == integration_name
+        ),
+        None,
+    )
+
+
+def get_app_integration_data(
+    model: jubilant.Juju,
+    app_name: str,
+    integration_name: str,
+    unit_num: int = 0,
+) -> dict | None:
+    """Get the application data for a given integration."""
+    data = get_integration_data(model, app_name, integration_name, unit_num)
+    return data["application-data"] if data else None
+
+
+def get_unit_address(juju: jubilant.Juju, app_name: str, unit_num: int = 0) -> str:
+    """Get the address of a given unit."""
+    data = get_unit_data(juju, f"{app_name}/{unit_num}")
+    return data["address"]
+
+
+@contextmanager
+def remove_integration(
+    juju: jubilant.Juju, /, remote_app_name: str, integration_name: str
+) -> Iterator[None]:
+    """Temporarily remove an integration from the application.
+
+    Integration is restored after the context is exited.
+    """
+
+    # The pre-existing integration instance can still be "dying" when the `finally` block
+    # is called, so `tenacity.retry` is used here to capture the `jubilant.CLIError`
+    # and re-run `juju integrate ...` until the previous integration instance has finished dying.
+    @retry(
+        wait=wait_exponential(multiplier=2, min=1, max=30),
+        stop=stop_after_attempt(10),
+        reraise=True,
+    )
+    def _reintegrate() -> None:
+        juju.integrate(f"{ADMIN_SERVICE_APP}:{integration_name}", remote_app_name)
+
+    juju.remove_relation(f"{ADMIN_SERVICE_APP}:{integration_name}", remote_app_name)
+    try:
+        yield
+    finally:
+        _reintegrate()
+
+
+def all_active(*apps: str) -> StatusPredicate:
+    return lambda status: jubilant.all_active(status, *apps)
+
+
+def all_blocked(*apps: str) -> StatusPredicate:
+    return lambda status: jubilant.all_blocked(status, *apps)
+
+
+def all_waiting(*apps: str) -> StatusPredicate:
+    return lambda status: jubilant.all_waiting(status, *apps)
+
+
+def any_error(*apps: str) -> StatusPredicate:
+    return lambda status: jubilant.any_error(status, *apps)
+
+
+def is_active(app: str) -> StatusPredicate:
+    return lambda status: status.apps[app].is_active
+
+
+def is_blocked(app: str) -> StatusPredicate:
+    return lambda status: status.apps[app].is_blocked
+
+
+def unit_number(app: str, expected_num: int) -> StatusPredicate:
+    return lambda status: len(status.apps[app].units) == expected_num
+
+
+def and_(*predicates: StatusPredicate) -> StatusPredicate:
+    return lambda status: all(predicate(status) for predicate in predicates)
+
+
+def or_(*predicates: StatusPredicate) -> StatusPredicate:
+    return lambda status: any(predicate(status) for predicate in predicates)

--- a/tox.ini
+++ b/tox.ini
@@ -71,5 +71,4 @@ pass_env =
 deps =
     -r{toxinidir}/integration-requirements.txt
 commands =
-    playwright install --with-deps
-    pytest -v --tb native {[vars]tst_path}integration --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native {[vars]tst_path}integration --log-cli-level=INFO --log-disable=jubilant.wait -s {posargs}


### PR DESCRIPTION
IAM-1854

- Migrate integration tests to jubilant
- Fix an issue with the cert transfer integration
- Update copilot instructions

The tests for the oauth integration have been removed because the lib relied on pytest-operator and async logic. We will need to re-implement them once the lib has been updated.